### PR TITLE
Fix error with Share Alliance Post

### DIFF
--- a/Mission-Alarm-Time.user.js
+++ b/Mission-Alarm-Time.user.js
@@ -25,6 +25,5 @@
             distanceTime.find('.calculateTime').click();
             observer.observe(distanceTime[0], { childList: true });
         }
-        $('.customAllianceShareText:first-of-type').click();
     });
 })();

--- a/Mission-Alarm-Time.user.js
+++ b/Mission-Alarm-Time.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         LSS-Mission-Alarm-Time
 // @namespace    http://tampermonkey.net/
-// @version      1.2.0
+// @version      1.2.1
 // @description  Shows the maximum time of all selected vehicles.
 // @author       Jan (KBOE2)
 // @include      /^https?:\/\/[www.]*(?:leitstellenspiel\.de|missionchief\.co\.uk|missionchief\.com|meldkamerspel\.com|centro-de-mando\.es|missionchief-australia\.com|larmcentralen-spelet\.se|operatorratunkowy\.pl|operatore112\.it|operateur112\.fr|dispetcher112\.ru|alarmcentral-spil\.dk|nodsentralspillet\.com|operacni-stredisko\.cz|112-merkez\.com|jogo-operador112\.com|operador193\.com|centro-de-mando\.mx|dyspetcher101-game\.com|missionchief-japan\.com|hatakeskuspeli\.com|missionchief-korea\.com|jocdispecerat112\.com|dispecerske-centrum\.com)\/missions\/.*$/


### PR DESCRIPTION
Because of the "$('.customAllianceShareText:first-of-type').click(); " It will reset the Share Alliance Post message to the first message. 
So every time that I forget to select a vehicle and select it, it resets the message. 
I don't see the reason why this should happen with this script.